### PR TITLE
Fix hash keys for plugin setting.

### DIFF
--- a/src/redmine_chatwork/lib/redmine_chatwork/listener.rb
+++ b/src/redmine_chatwork/lib/redmine_chatwork/listener.rb
@@ -32,7 +32,7 @@ class ChatWorkListener < Redmine::Hook::Listener
     disabled = check_disabled issue.project
 
     return if disabled
-    return unless room and Setting.plugin_redmine_chatwork[:post_updates] == '1'
+    return unless room and Setting.plugin_redmine_chatwork['post_updates'] == '1'
     return if issue.is_private?
     return if not journal.notes
 
@@ -54,7 +54,7 @@ class ChatWorkListener < Redmine::Hook::Listener
   end
 
   def controller_wiki_edit_after_save(context = {})
-    return unless Setting.plugin_redmine_chatwork[:post_wiki_updates] == '1'
+    return unless Setting.plugin_redmine_chatwork['post_wiki_updates'] == '1'
 
     project = context[:project]
     page = context[:page]
@@ -76,7 +76,7 @@ class ChatWorkListener < Redmine::Hook::Listener
 
   def speak(room, header, body=nil, footer=nil)
     url = 'https://api.chatwork.com/v2/rooms/'
-    token = Setting.plugin_redmine_chatwork[:token]
+    token = Setting.plugin_redmine_chatwork['token']
     content = create_body body, header, footer
     reqHeader = {'X-ChatWorkToken' => token}
     endpoint = "#{url}#{room}/messages"
@@ -160,7 +160,7 @@ class ChatWorkListener < Redmine::Hook::Listener
 
     val = [
         (proj.custom_value_for(cf).value rescue nil),
-        Setting.plugin_redmine_chatwork[:room],
+        Setting.plugin_redmine_chatwork['room'],
     ].find { |v| v.present? }
 
     rid = val.match(/#!rid\d+/)


### PR DESCRIPTION
I think that `Setting.plugin_redmine_chatwork` needs keys as string not symbol.

My environment:
- Redmine version 3.4.4.stable.17197
- Ruby version 2.5.0-p0 (2017-12-25) [x86_64-freebsd10.3]
- Rails version 4.2.8
